### PR TITLE
fix: function highlight ends after fun name

### DIFF
--- a/src/flix.js
+++ b/src/flix.js
@@ -51,16 +51,10 @@ export default function(hljs) {
       ]
     };
 
-    const PARAMS = {
-      scope: 'params',
-      begin: NAME + 's*:s*' + NAME,
-      end: ',|)'
-    };
-
     const METHOD = {
       scope: 'title.function',
       beginKeywords: 'def',
-      end: /\)/,
+      end: /[(\[]/,
       excludeEnd: true,
       contains: [
         NAME


### PR DESCRIPTION
Previous commit highlighted functions wrong.