### PR TITLE
feat: add highlighting for `get` and `set`

### DIFF
--- a/src/flix.js
+++ b/src/flix.js
@@ -84,6 +84,8 @@ export default function(hljs) {
       "foreach",
       "import",
       "use",
+      "get",
+      "set",
       "new",
       "catch",
       "class",


### PR DESCRIPTION
Related to https://github.com/flix/highlight.js/issues/23