### PR TITLE
chore: reflect renaming of `debug` to `dbg`

### DIFF
--- a/src/flix.js
+++ b/src/flix.js
@@ -166,9 +166,9 @@ export default function(hljs) {
     ];
 
     const BUILTIN = [
-      "debug",
-      "debug!",
-      "debug!!",
+      "dbg",
+      "dbg!",
+      "dbg!!",
       "IO",
       "ef",
       "ef1",


### PR DESCRIPTION
Related to https://github.com/flix/flix/issues/8626