### PR TITLE
chore: drop `do` keyword

### DIFF
--- a/src/flix.js
+++ b/src/flix.js
@@ -85,7 +85,6 @@ export default function(hljs) {
       "checked_ecast",
       "default",
       "def",
-      "do",
       "eff",
       "else",
       "enum",


### PR DESCRIPTION
Related to flix/flix#8926